### PR TITLE
Regular users: manage THEIR tickets

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Ticket;
+use Illuminate\Support\Facades\Auth;
+
+class CommentController extends Controller
+{
+    public function store(Request $request, Ticket $ticket)
+    {
+        $request->validate([
+            'content' => 'required|string|max:500',
+        ]);
+
+        // Create the comment
+        $ticket->comments()->create([
+            'user_id' => Auth::id(),
+            'content' => $request->input('content'),
+        ]);
+
+        // Redirect back to the ticket details page
+        return redirect()->route('tickets.show', $ticket->id)->with('success', 'Comment added successfully.');
+    }
+}

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Ticket;
+use App\Models\Category;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
+
+class TicketController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request)
+    {
+        // Validate the request data
+        $validator = Validator::make($request->all(), [
+            'status' => 'nullable|string|in:open,closed', // Adjust based on your status options
+            'priority' => 'nullable|string|in:low,medium,high', // Adjust based on your priority options
+            'category_id' => 'nullable|exists:categories,id',
+        ]);
+
+        // Check if validation fails
+        if ($validator->fails()) {
+            // Redirect or return a response with validation errors
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        $user = Auth::user();
+
+        // Apply filters for status, priority, and category
+        $tickets = Ticket::where('user_id', $user->id)
+            ->when($request->status, function($query) use ($request) {
+                $query->where('status', $request->status);
+            })
+            ->when($request->priority, function($query) use ($request) {
+                $query->where('priority', $request->priority);
+            })
+            ->when($request->category_id, function($query) use ($request) {
+                $query->whereHas('categories', function($query) use ($request) {
+                    $query->where('categories.id', $request->category_id);
+                });
+            })
+            ->get();
+
+        $categories = Category::all();
+
+        return view('tickets.index', compact('tickets', 'categories'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        // Fetch categories to pass to the view
+        $categories = Category::all();
+
+        // Display the form for creating a new ticket
+        return view('tickets.create', compact('categories'));
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        // Validate and store the new ticket
+        $request->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string', // Ensure description is validated
+            'priority' => 'required|in:low,medium,high',
+            'status' => 'required|in:open,closed',
+            'category_id' => 'nullable|exists:categories,id',
+        ]);
+
+        Ticket::create([
+            'title' => $request->title,
+            'description' => $request->description, // Include description in the created ticket
+            'priority' => $request->priority,
+            'status' => $request->status,
+            'category_id' => $request->category_id,
+            'user_id' => auth()->id(), // Assuming the user is logged in
+        ]);
+
+        return redirect()->route('tickets.index')->with('success', 'Ticket created successfully.');
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Ticket $ticket)
+    {
+        // Make sure the user can only view their own tickets
+        if (Auth::id() !== $ticket->user_id) {
+            abort(403, 'Unauthorized');
+        }
+    
+        // Load the ticket's comments and activity logs (assuming these relations exist)
+        $ticket->load('comments', 'activityLogs');
+    
+        return view('tickets.show', compact('ticket'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Models/ActivityLog.php
+++ b/app/Models/ActivityLog.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ActivityLog extends Model
+{
+    use HasFactory;
+    
+    protected $fillable = ['ticket_id', 'description'];
+
+    public function ticket()
+    {
+        return $this->belongsTo(Ticket::class);
+    }
+}

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    use HasFactory;
+    protected $fillable = ['ticket_id', 'user_id', 'content'];
+
+    public function ticket()
+    {
+        return $this->belongsTo(Ticket::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -11,6 +11,16 @@ class Ticket extends Model
 
     protected $fillable = ['title', 'description', 'priority', 'status', 'user_id'];
 
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
+
+    public function activityLogs()
+    {
+        return $this->hasMany(ActivityLog::class);
+    }
+
     public function userAgent()
     {
         return $this->belongsTo(User::class, 'user_id');

--- a/database/migrations/2024_09_19_110414_create_comments_table.php
+++ b/database/migrations/2024_09_19_110414_create_comments_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ticket_id')->constrained()->onDelete('cascade');
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->text('content');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('comments');
+    }
+};

--- a/database/migrations/2024_09_19_110709_create_activity_logs_table.php
+++ b/database/migrations/2024_09_19_110709_create_activity_logs_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('activity_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('ticket_id')->constrained()->onDelete('cascade');
+            $table->string('description');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('activity_logs');
+    }
+};

--- a/resources/views/tickets/create.blade.php
+++ b/resources/views/tickets/create.blade.php
@@ -1,0 +1,56 @@
+<!-- resources/views/tickets/create.blade.php -->
+
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Create New Ticket') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="container">
+                    <h1>Create a New Ticket</h1>
+
+                    <form method="POST" action="{{ route('tickets.store') }}">
+                        @csrf
+                        <div class="mb-4">
+                            <label for="title">Title</label>
+                            <input type="text" id="title" name="title" class="form-input" required>
+                        </div>
+                        <div class="mb-4">
+                            <label for="description">Description</label>
+                            <textarea id="description" name="description" class="form-textarea" rows="4"></textarea>
+                        </div>
+                        <div class="mb-4">
+                            <label for="priority">Priority</label>
+                            <select id="priority" name="priority" class="form-select" required>
+                                <option value="low">Low</option>
+                                <option value="medium">Medium</option>
+                                <option value="high">High</option>
+                            </select>
+                        </div>
+                        <div class="mb-4">
+                            <label for="status">Status</label>
+                            <select id="status" name="status" class="form-select" required>
+                                <option value="open">Open</option>
+                                <option value="closed">Closed</option>
+                            </select>
+                        </div>
+                        <div class="mb-4">
+                            <label for="category_id">Category</label>
+                            <select id="category_id" name="category_id" class="form-select">
+                                <option value="">None</option>
+                                @foreach($categories as $category)
+                                    <option value="{{ $category->id }}">{{ $category->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <button type="submit" class="border border-black">Create Ticket</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/tickets/index.blade.php
+++ b/resources/views/tickets/index.blade.php
@@ -1,0 +1,84 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Tickets') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="container">
+                    <h1>Your Tickets</h1>
+                    
+                    <!-- Create New Ticket Button -->
+                    <div class="mb-3">
+                        <a href="{{ route('tickets.create') }}" class="border border-black">Create New Ticket</a>
+                    </div>
+                    
+                    <div class="mb-3">
+                        <form method="GET" action="{{ route('tickets.index') }}">
+                            <!-- Status Filter -->
+                            <label for="status">Status</label>
+                            <select name="status">
+                                <option value="" {{ request('status') == '' ? 'selected' : '' }}>All</option>
+                                <option value="open" {{ request('status') == 'open' ? 'selected' : '' }}>Open</option>
+                                <option value="closed" {{ request('status') == 'closed' ? 'selected' : '' }}>Closed</option>
+                            </select>
+
+                            <!-- Priority Filter -->
+                            <label for="priority">Priority</label>
+                            <select name="priority">
+                                <option value="" {{ request('priority') == '' ? 'selected' : '' }}>All</option>
+                                <option value="low" {{ request('priority') == 'low' ? 'selected' : '' }}>Low</option>
+                                <option value="medium" {{ request('priority') == 'medium' ? 'selected' : '' }}>Medium</option>
+                                <option value="high" {{ request('priority') == 'high' ? 'selected' : '' }}>High</option>
+                            </select>
+
+                            <!-- Category Filter -->
+                            <label for="category_id">Category</label>
+                            <select name="category_id">
+                                <option value="" {{ request('category_id') == '' ? 'selected' : '' }}>All</option>
+                                @foreach ($categories as $category)
+                                    <option value="{{ $category->id }}" {{ request('category_id') == $category->id ? 'selected' : '' }}>
+                                        {{ $category->name }}
+                                    </option>
+                                @endforeach
+                            </select>
+                
+                            <button type="submit" class="border border-black">Filter</button>
+                        </form>
+                    </div>
+                
+                    <!-- Ticket table -->
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th class="border border-black">Title</th>
+                                <th class="border border-black">Priority</th>
+                                <th class="border border-black">Status</th>
+                                <th class="border border-black">Category</th>
+                                <th class="border border-black">Created At</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($tickets as $ticket)
+                                <tr>
+                                    <td class="border border-black"><a class="text-blue-600 underline" href="{{ route('tickets.show', $ticket->id) }}">{{ $ticket->title }}</a></td>
+                                    <td class="border border-black">{{ ucfirst($ticket->priority) }}</td>
+                                    <td class="border border-black">{{ ucfirst($ticket->status) }}</td>
+                                    <td class="border border-black">
+                                        @foreach($ticket->categories as $category)
+                                            {{ $category->name }}
+                                        @endforeach
+                                    </td>
+                                    <td class="border border-black">{{ $ticket->created_at->format('Y-m-d') }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -1,0 +1,54 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Ticket Details') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <h1>{{ $ticket->title }}</h1>
+
+                    <!-- Ticket Details -->
+                    <p><strong>Status:</strong> {{ ucfirst($ticket->status) }}</p>
+                    <p><strong>Priority:</strong> {{ ucfirst($ticket->priority) }}</p>
+                    <p><strong>Category:</strong>
+                        @foreach($ticket->categories as $category)
+                            {{ $category->name }}
+                        @endforeach
+                    </p>
+                    <p><strong>Created At:</strong> {{ $ticket->created_at->format('Y-m-d H:i:s') }}</p>
+                    <p><strong>Description:</strong> {{ $ticket->description }}</p>
+
+                    <!-- Activity Log -->
+                    <h2>Activity Log</h2>
+                    <ul>
+                        @foreach($ticket->activityLogs as $log)
+                            <li>{{ $log->description }} ({{ $log->created_at->format('Y-m-d H:i:s') }})</li>
+                        @endforeach
+                    </ul>
+
+                    <!-- Comments Section -->
+                    <h2>Comments</h2>
+                    <ul>
+                        @foreach($ticket->comments as $comment)
+                            <li><strong>{{ $comment->user->name }}:</strong> {{ $comment->content }} ({{ $comment->created_at->format('Y-m-d H:i:s') }})</li>
+                        @endforeach
+                    </ul>
+
+                    <!-- Add Comment Form -->
+                    <h3>Add a Comment</h3>
+                    <form method="POST" action="{{ route('comments.store', $ticket->id) }}">
+                        @csrf
+                        <div>
+                            <textarea name="content" rows="4" class="w-full border border-gray-300"></textarea>
+                        </div>
+                        <button type="submit" class="mt-2 bg-blue-500 text-white px-4 py-2 rounded">Submit</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,8 @@
 
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\TicketController;
+use App\Http\Controllers\CommentController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -12,6 +14,11 @@ Route::get('/dashboard', function () {
 })->middleware(['auth', 'verified'])->name('dashboard');
 
 Route::middleware('auth')->group(function () {
+    Route::resource('tickets', TicketController::class)->except(['edit', 'update', 'destroy']);
+    
+    // Route for adding comments to tickets
+    Route::post('/tickets/{ticket}/comments', [CommentController::class, 'store'])->name('comments.store');
+
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');


### PR DESCRIPTION
After registration/login, user sees the only menu item 'Tickets' with a table of tickets only created by themselves. Table of tickets needs to have dropdown filters: by status, priority and category. They can add a new ticket, but can't edit/delete tickets. They can click the ticket title in the table to open the page to see more details and ticket activity log and comments, also may add a comment there (more on that later).