### PR TITLE
Admin users: manage everything

### DIFF
--- a/app/Http/Controllers/ActivityLogController.php
+++ b/app/Http/Controllers/ActivityLogController.php
@@ -1,0 +1,18 @@
+<?php
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\ActivityLog;
+
+class ActivityLogController extends Controller
+{
+    /**
+     * Display the activity log for tickets.
+     */
+    public function index()
+    {
+        // Retrieve all ticket-related activity logs in reverse order
+        $logs = ActivityLog::orderBy('created_at', 'desc')->get();
+        return view('admin.activitylogs.index', compact('logs'));
+    }
+}

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -1,0 +1,25 @@
+<?php
+// AdminController.php
+
+namespace App\Http\Controllers;
+
+use App\Models\Ticket;
+use Illuminate\Http\Request;
+
+class AdminController extends Controller
+{
+    public function dashboard()
+    {
+        // Get ticket counts
+        $totalTickets = Ticket::count();
+        $openTickets = Ticket::where('status', 'open')->count();
+        $closedTickets = Ticket::where('status', 'closed')->count();
+
+        return view('admin.dashboard', compact('totalTickets', 'openTickets', 'closedTickets'));
+    }
+
+    public function logs()
+    {
+
+    }
+}

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -1,0 +1,51 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Category;
+use Illuminate\Http\Request;
+
+class CategoryController extends Controller
+{
+    // Show all categories
+    public function index()
+    {
+        $categories = Category::all(); // Fetch all categories from the database
+        return view('categories.index', compact('categories')); // Pass categories to the view
+    }
+
+    // Store a new category
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255|unique:categories,name', // Validate input
+        ]);
+
+        Category::create([
+            'name' => $request->name,
+        ]);
+
+        return redirect()->route('categories.index')->with('success', 'Category created successfully.');
+    }
+
+    // Update an existing category
+    public function update(Request $request, Category $category)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255|unique:categories,name,' . $category->id, // Validate input
+        ]);
+
+        $category->update([
+            'name' => $request->name,
+        ]);
+
+        return redirect()->route('categories.index')->with('success', 'Category updated successfully.');
+    }
+
+    // Delete a category
+    public function destroy(Category $category)
+    {
+        $category->delete();
+
+        return redirect()->route('categories.index')->with('success', 'Category deleted successfully.');
+    }
+}

--- a/app/Http/Controllers/LabelController.php
+++ b/app/Http/Controllers/LabelController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Label;
+
+class LabelController extends Controller
+{
+    // Show all labels
+    public function index()
+    {
+        $labels = Label::all(); // Fetch all labels from the database
+        return view('labels.index', compact('labels')); // Pass labels to the view
+    }
+
+    // Store a new label
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255|unique:labels,name', // Validate input
+        ]);
+
+        Label::create([
+            'name' => $request->name,
+        ]);
+
+        return redirect()->route('labels.index')->with('success', 'Label created successfully.');
+    }
+
+    // Update an existing label
+    public function update(Request $request, Label $label)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255|unique:labels,name,' . $label->id, // Validate input
+        ]);
+
+        $label->update([
+            'name' => $request->name,
+        ]);
+
+        return redirect()->route('labels.index')->with('success', 'Label updated successfully.');
+    }
+
+    // Delete a label
+    public function destroy(Label $label)
+    {
+        $label->delete();
+
+        return redirect()->route('labels.index')->with('success', 'Label deleted successfully.');
+    }
+}

--- a/app/Http/Middleware/AdminMiddleware.php
+++ b/app/Http/Middleware/AdminMiddleware.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AdminMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        // Check if user is authenticated and has role 'admin'
+        if (Auth::check() && Auth::user()->role === 'admin') {
+            return $next($request);
+        } else {
+            return redirect('/home'); // Redirect or show unauthorized access message
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^11.9",
-        "laravel/tinker": "^2.9"
+        "laravel/tinker": "^2.9",
+        "spatie/laravel-activitylog": "^4.8"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df0ce24d017afea787ce0ea993b46f8c",
+    "content-hash": "ca8879e34b40b5d18cc1bc40832d6817",
     "packages": [
         {
             "name": "brick/math",
@@ -3110,6 +3110,157 @@
                 }
             ],
             "time": "2024-04-27T21:32:50+00:00"
+        },
+        {
+            "name": "spatie/laravel-activitylog",
+            "version": "4.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-activitylog.git",
+                "reference": "eb6f37dd40af950ce10cf5280f0acfa3e08c3bff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-activitylog/zipball/eb6f37dd40af950ce10cf5280f0acfa3e08c3bff",
+                "reference": "eb6f37dd40af950ce10cf5280f0acfa3e08c3bff",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/config": "^8.0 || ^9.0 || ^10.0 || ^11.0",
+                "illuminate/database": "^8.69 || ^9.27 || ^10.0 || ^11.0",
+                "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0",
+                "php": "^8.1",
+                "spatie/laravel-package-tools": "^1.6.3"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "orchestra/testbench": "^6.23 || ^7.0 || ^8.0 || ^9.0",
+                "pestphp/pest": "^1.20 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Activitylog\\ActivitylogServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Activitylog\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Tom Witkowski",
+                    "email": "dev.gummibeer@gmail.com",
+                    "homepage": "https://gummibeer.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A very simple activity logger to monitor the users of your website or application",
+            "homepage": "https://github.com/spatie/activitylog",
+            "keywords": [
+                "activity",
+                "laravel",
+                "log",
+                "spatie",
+                "user"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-activitylog/issues",
+                "source": "https://github.com/spatie/laravel-activitylog/tree/4.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-08T22:28:17+00:00"
+        },
+        {
+            "name": "spatie/laravel-package-tools",
+            "version": "1.16.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-package-tools.git",
+                "reference": "c7413972cf22ffdff97b68499c22baa04eddb6a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/c7413972cf22ffdff97b68499c22baa04eddb6a2",
+                "reference": "c7413972cf22ffdff97b68499c22baa04eddb6a2",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^9.28|^10.0|^11.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.5",
+                "orchestra/testbench": "^7.7|^8.0",
+                "pestphp/pest": "^1.22",
+                "phpunit/phpunit": "^9.5.24",
+                "spatie/pest-plugin-test-time": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\LaravelPackageTools\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Tools for creating Laravel packages",
+            "homepage": "https://github.com/spatie/laravel-package-tools",
+            "keywords": [
+                "laravel-package-tools",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-package-tools/issues",
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.16.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-27T18:56:10+00:00"
         },
         {
             "name": "symfony/clock",

--- a/resources/views/admin/activitylogs/index.blade.php
+++ b/resources/views/admin/activitylogs/index.blade.php
@@ -1,0 +1,36 @@
+<!-- resources/views/logs/index.blade.php -->
+
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Ticket Logs') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <h1>Ticket Activity Logs</h1>
+
+                    <table class="min-w-full table-auto">
+                        <thead>
+                            <tr>
+                                <th class="px-4 py-2">Description</th>
+                                <th class="px-4 py-2">Date</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($logs as $log)
+                                <tr>
+                                    <td class="border px-4 py-2">{{ $log->description }}</td>
+                                    <td class="border px-4 py-2">{{ $log->created_at->format('Y-m-d H:i:s') }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,34 @@
+<!-- resources/views/admin/dashboard.blade.php -->
+
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Admin Dashboard') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <h1>Dashboard</h1>
+
+                    <div class="grid grid-cols-3 gap-4">
+                        <div class="p-4 bg-gray-100 border border-gray-300 rounded">
+                            <h2>Total Tickets</h2>
+                            <p>{{ $totalTickets }}</p>
+                        </div>
+                        <div class="p-4 bg-gray-100 border border-gray-300 rounded">
+                            <h2>Open Tickets</h2>
+                            <p>{{ $openTickets }}</p>
+                        </div>
+                        <div class="p-4 bg-gray-100 border border-gray-300 rounded">
+                            <h2>Closed Tickets</h2>
+                            <p>{{ $closedTickets }}</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -1,0 +1,69 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Categories') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <!-- Create New Category Form -->
+                    <h2 class="text-lg font-semibold mb-4">Create New Category</h2>
+                    <form method="POST" action="{{ route('categories.store') }}">
+                        @csrf
+                        <div class="mb-4">
+                            <label for="name" class="block text-sm font-medium text-gray-700">Category Name</label>
+                            <input type="text" id="name" name="name" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm" required>
+                            @error('name')
+                                <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                            @enderror
+                        </div>
+                        <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded-md">Create Category</button>
+                    </form>
+
+                    <!-- Categories Table -->
+                    <h2 class="text-lg font-semibold mt-8 mb-4">Existing Categories</h2>
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Category</th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            @foreach ($categories as $category)
+                                <tr>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ $category->name }}</td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                                        <!-- Edit Button -->
+                                        <a href="#" class="text-blue-600 hover:text-blue-900" onclick="document.getElementById('edit-form-{{ $category->id }}').classList.toggle('hidden')">Edit</a>
+                                        
+                                        <!-- Edit Form -->
+                                        <form id="edit-form-{{ $category->id }}" action="{{ route('categories.update', $category->id) }}" method="POST" class="hidden mt-2">
+                                            @csrf
+                                            @method('PATCH')
+                                            <div class="mb-4">
+                                                <label for="edit-name-{{ $category->id }}" class="block text-sm font-medium text-gray-700">New Name</label>
+                                                <input type="text" id="edit-name-{{ $category->id }}" name="name" value="{{ $category->name }}" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm" required>
+                                            </div>
+                                            <button type="submit" class="bg-yellow-500 text-white px-4 py-2 rounded-md">Update</button>
+                                        </form>
+                                        
+                                        <!-- Delete Button -->
+                                        <form action="{{ route('categories.destroy', $category->id) }}" method="POST" class="inline-block ml-2">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="text-red-600 hover:text-red-900" onclick="return confirm('Are you sure you want to delete this category?')">Delete</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/labels/index.blade.php
+++ b/resources/views/labels/index.blade.php
@@ -1,0 +1,69 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Labels Management') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <!-- Create New Label Form -->
+                    <h2 class="text-lg font-semibold mb-4">Create New Label</h2>
+                    <form method="POST" action="{{ route('labels.store') }}">
+                        @csrf
+                        <div class="mb-4">
+                            <label for="name" class="block text-sm font-medium text-gray-700">Label Name</label>
+                            <input type="text" id="name" name="name" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm" required>
+                            @error('name')
+                                <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                            @enderror
+                        </div>
+                        <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded-md">Create Label</button>
+                    </form>
+
+                    <!-- Labels Table -->
+                    <h2 class="text-lg font-semibold mt-8 mb-4">Existing Labels</h2>
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Label</th>
+                                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            @foreach ($labels as $label)
+                                <tr>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ $label->name }}</td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                                        <!-- Edit Button -->
+                                        <a href="#" class="text-blue-600 hover:text-blue-900" onclick="document.getElementById('edit-form-{{ $label->id }}').classList.toggle('hidden')">Edit</a>
+                                        
+                                        <!-- Edit Form -->
+                                        <form id="edit-form-{{ $label->id }}" action="{{ route('labels.update', $label->id) }}" method="POST" class="hidden mt-2">
+                                            @csrf
+                                            @method('PATCH')
+                                            <div class="mb-4">
+                                                <label for="edit-name-{{ $label->id }}" class="block text-sm font-medium text-gray-700">New Name</label>
+                                                <input type="text" id="edit-name-{{ $label->id }}" name="name" value="{{ $label->name }}" class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm" required>
+                                            </div>
+                                            <button type="submit" class="bg-yellow-500 text-white px-4 py-2 rounded-md">Update</button>
+                                        </form>
+                                        
+                                        <!-- Delete Button -->
+                                        <form action="{{ route('labels.destroy', $label->id) }}" method="POST" class="inline-block ml-2">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="text-red-600 hover:text-red-900" onclick="return confirm('Are you sure you want to delete this label?')">Delete</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -12,9 +12,38 @@
 
                 <!-- Navigation Links -->
                 <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
-                    <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
-                        {{ __('Dashboard') }}
+                    <!-- Dashboard Link (only for admins) -->
+                    @if(Auth::user()->role === 'admin')
+                        <x-nav-link :href="route('admin.dashboard')" :active="request()->routeIs('admin.dashboard')">
+                            {{ __('Dashboard') }}
+                        </x-nav-link>
+                    @endif
+
+                    <!-- Tickets Link (Visible to all users) -->
+                    <x-nav-link :href="route('tickets.index')" :active="request()->routeIs('tickets.index')">
+                        {{ __('Tickets') }}
                     </x-nav-link>
+
+                    <!-- Labels Link (Admin only) -->
+                    @if(Auth::user()->role === 'admin')
+                        <x-nav-link :href="route('labels.index')" :active="request()->routeIs('labels.index')">
+                            {{ __('Labels') }}
+                        </x-nav-link>
+                    @endif
+
+                    <!-- Categories Link (Admin only) -->
+                    @if(Auth::user()->role === 'admin')
+                        <x-nav-link :href="route('categories.index')" :active="request()->routeIs('categories.index')">
+                            {{ __('Categories') }}
+                        </x-nav-link>
+                    @endif
+
+                    <!-- Ticket Logs Link (Admin only) -->
+                    @if(Auth::user()->role === 'admin')
+                        <x-nav-link :href="route('admin.activitylogs.index')" :active="request()->routeIs('admin.activitylogs.index')">
+                            {{ __('Ticket Logs') }}
+                        </x-nav-link>
+                    @endif
                 </div>
             </div>
 
@@ -41,7 +70,6 @@
                         <!-- Authentication -->
                         <form method="POST" action="{{ route('logout') }}">
                             @csrf
-
                             <x-dropdown-link :href="route('logout')"
                                     onclick="event.preventDefault();
                                                 this.closest('form').submit();">
@@ -67,9 +95,38 @@
     <!-- Responsive Navigation Menu -->
     <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
         <div class="pt-2 pb-3 space-y-1">
-            <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
-                {{ __('Dashboard') }}
+            <!-- Dashboard Link (Admin Only) -->
+            @if(Auth::user()->role === 'admin')
+                <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
+                    {{ __('Dashboard') }}
+                </x-responsive-nav-link>
+            @endif
+
+            <!-- Tickets Link -->
+            <x-responsive-nav-link :href="route('tickets.index')" :active="request()->routeIs('tickets.index')">
+                {{ __('Tickets') }}
             </x-responsive-nav-link>
+
+            <!-- Labels Link (Admin Only) -->
+            @if(Auth::user()->role === 'admin')
+                <x-responsive-nav-link :href="route('labels.index')" :active="request()->routeIs('labels.index')">
+                    {{ __('Labels') }}
+                </x-responsive-nav-link>
+            @endif
+
+            <!-- Categories Link (Admin Only) -->
+            @if(Auth::user()->role === 'admin')
+                <x-responsive-nav-link :href="route('categories.index')" :active="request()->routeIs('categories.index')">
+                    {{ __('Categories') }}
+                </x-responsive-nav-link>
+            @endif
+            
+            <!-- Ticket Logs Link (Admin only) -->
+            @if(Auth::user()->role === 'admin')
+                <x-responsive-nav-link :href="route('admin.activitylogs.index')" :active="request()->routeIs('admin.activitylogs.index')">
+                    {{ __('Ticket Logs') }}
+                </x-responsive-nav-link>
+            @endif
         </div>
 
         <!-- Responsive Settings Options -->
@@ -87,7 +144,6 @@
                 <!-- Authentication -->
                 <form method="POST" action="{{ route('logout') }}">
                     @csrf
-
                     <x-responsive-nav-link :href="route('logout')"
                             onclick="event.preventDefault();
                                         this.closest('form').submit();">

--- a/resources/views/tickets/create.blade.php
+++ b/resources/views/tickets/create.blade.php
@@ -15,14 +15,20 @@
 
                     <form method="POST" action="{{ route('tickets.store') }}">
                         @csrf
+                        
+                        <!-- Title Field -->
                         <div class="mb-4">
                             <label for="title">Title</label>
                             <input type="text" id="title" name="title" class="form-input" required>
                         </div>
+                        
+                        <!-- Description Field -->
                         <div class="mb-4">
                             <label for="description">Description</label>
                             <textarea id="description" name="description" class="form-textarea" rows="4"></textarea>
                         </div>
+
+                        <!-- Priority Dropdown -->
                         <div class="mb-4">
                             <label for="priority">Priority</label>
                             <select id="priority" name="priority" class="form-select" required>
@@ -31,6 +37,8 @@
                                 <option value="high">High</option>
                             </select>
                         </div>
+
+                        <!-- Status Dropdown -->
                         <div class="mb-4">
                             <label for="status">Status</label>
                             <select id="status" name="status" class="form-select" required>
@@ -38,15 +46,30 @@
                                 <option value="closed">Closed</option>
                             </select>
                         </div>
+
+                        <!-- Category Checkboxes -->
                         <div class="mb-4">
-                            <label for="category_id">Category</label>
-                            <select id="category_id" name="category_id" class="form-select">
-                                <option value="">None</option>
-                                @foreach($categories as $category)
-                                    <option value="{{ $category->id }}">{{ $category->name }}</option>
-                                @endforeach
-                            </select>
+                            <label>Categories</label><br>
+                            @foreach($categories as $category)
+                                <div>
+                                    <input type="checkbox" id="category_{{ $category->id }}" name="categories[]" value="{{ $category->id }}">
+                                    <label for="category_{{ $category->id }}">{{ $category->name }}</label>
+                                </div>
+                            @endforeach
                         </div>
+
+                        <!-- Labels Checkboxes -->
+                        <div class="mb-4">
+                            <label>Labels</label><br>
+                            @foreach($labels as $label)
+                                <div>
+                                    <input type="checkbox" id="label_{{ $label->id }}" name="labels[]" value="{{ $label->id }}">
+                                    <label for="label_{{ $label->id }}">{{ $label->name }}</label>
+                                </div>
+                            @endforeach
+                        </div>
+
+                        <!-- Submit Button -->
                         <button type="submit" class="border border-black">Create Ticket</button>
                     </form>
                 </div>

--- a/resources/views/tickets/edit.blade.php
+++ b/resources/views/tickets/edit.blade.php
@@ -1,0 +1,96 @@
+<!-- resources/views/tickets/edit.blade.php -->
+
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Edit Ticket') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <h1>Edit Ticket</h1>
+
+                    <form method="POST" action="{{ route('tickets.update', $ticket->id) }}">
+                        @csrf
+                        @method('PUT')
+
+                        <!-- Title Field -->
+                        <div class="mb-4">
+                            <label for="title">Title</label>
+                            <input type="text" id="title" name="title" value="{{ old('title', $ticket->title) }}" class="form-input" required>
+                        </div>
+
+                        <!-- Description Field -->
+                        <div class="mb-4">
+                            <label for="description">Description</label>
+                            <textarea id="description" name="description" class="form-textarea" required>{{ old('description', $ticket->description) }}</textarea>
+                        </div>
+
+                        <!-- Priority Dropdown -->
+                        <div class="mb-4">
+                            <label for="priority">Priority</label>
+                            <select id="priority" name="priority" class="form-select" required>
+                                <option value="low" {{ $ticket->priority == 'low' ? 'selected' : '' }}>Low</option>
+                                <option value="medium" {{ $ticket->priority == 'medium' ? 'selected' : '' }}>Medium</option>
+                                <option value="high" {{ $ticket->priority == 'high' ? 'selected' : '' }}>High</option>
+                            </select>
+                        </div>
+
+                        <!-- Status Dropdown -->
+                        <div class="mb-4">
+                            <label for="status">Status</label>
+                            <select id="status" name="status" class="form-select" required>
+                                <option value="open" {{ $ticket->status == 'open' ? 'selected' : '' }}>Open</option>
+                                <option value="closed" {{ $ticket->status == 'closed' ? 'selected' : '' }}>Closed</option>
+                            </select>
+                        </div>
+
+                        <!-- Category Checkboxes -->
+                        <div class="mb-4">
+                            <label>Categories</label><br>
+                            @foreach($categories as $category)
+                                <div>
+                                    <input type="checkbox" id="category_{{ $category->id }}" name="categories[]" value="{{ $category->id }}"
+                                        {{ in_array($category->id, $ticket->categories->pluck('id')->toArray()) ? 'checked' : '' }}>
+                                    <label for="category_{{ $category->id }}">{{ $category->name }}</label>
+                                </div>
+                            @endforeach
+                        </div>
+
+                        <!-- Labels Checkboxes -->
+                        <div class="mb-4">
+                            <label>Labels</label><br>
+                            @foreach($labels as $label)
+                                <div>
+                                    <input type="checkbox" id="label_{{ $label->id }}" name="labels[]" value="{{ $label->id }}"
+                                        {{ in_array($label->id, $ticket->labels->pluck('id')->toArray()) ? 'checked' : '' }}>
+                                    <label for="label_{{ $label->id }}">{{ $label->name }}</label>
+                                </div>
+                            @endforeach
+                        </div>
+
+                        <!-- Assign Agent Dropdown (Only for Admins) -->
+                        @if(Auth::user()->role === 'admin') <!-- Check if user has permission to assign an agent -->
+                            <div class="mb-4">
+                                <label for="user_agent">Assign Agent</label>
+                                <select id="user_agent" name="user_agent_id" class="form-select">
+                                    <option value="">Unassigned</option> <!-- Allow ticket to remain unassigned -->
+                                    @foreach($user_agents as $user_agent)
+                                        <option value="{{ $user_agent->id }}" {{ $ticket->user_id == $user_agent->id ? 'selected' : '' }}>
+                                            {{ $user_agent->name }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        @endif
+
+                        <button type="submit" class="border border-black">Update Ticket</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/tickets/index.blade.php
+++ b/resources/views/tickets/index.blade.php
@@ -59,12 +59,13 @@
                                 <th class="border border-black">Status</th>
                                 <th class="border border-black">Category</th>
                                 <th class="border border-black">Created At</th>
+                                <th class="border border-black">Actions</th> <!-- Added actions column -->
                             </tr>
                         </thead>
                         <tbody>
                             @foreach($tickets as $ticket)
                                 <tr>
-                                    <td class="border border-black"><a class="text-blue-600 underline" href="{{ route('tickets.show', $ticket->id) }}">{{ $ticket->title }}</a></td>
+                                    <td class="border border-black">{{ $ticket->title }}</td>
                                     <td class="border border-black">{{ ucfirst($ticket->priority) }}</td>
                                     <td class="border border-black">{{ ucfirst($ticket->status) }}</td>
                                     <td class="border border-black">
@@ -73,6 +74,11 @@
                                         @endforeach
                                     </td>
                                     <td class="border border-black">{{ $ticket->created_at->format('Y-m-d') }}</td>
+                                    <td class="border border-black">
+                                        <!-- View and Edit Links -->
+                                        <a class="text-blue-600 underline" href="{{ route('tickets.show', $ticket->id) }}">View</a> | 
+                                        @if(Auth::user()->role === 'admin')<a class="text-blue-600 underline" href="{{ route('tickets.edit', $ticket->id) }}">Edit</a>@endif
+                                    </td>
                                 </tr>
                             @endforeach
                         </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,9 +1,14 @@
 <?php
 
+use App\Http\Controllers\CategoryController;
+use App\Http\Controllers\LabelController;
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\TicketController;
 use App\Http\Controllers\CommentController;
+use App\Http\Controllers\AdminController;
+use App\Http\Middleware\AdminMiddleware;
+use App\Http\Controllers\ActivityLogController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -14,10 +19,25 @@ Route::get('/dashboard', function () {
 })->middleware(['auth', 'verified'])->name('dashboard');
 
 Route::middleware('auth')->group(function () {
-    Route::resource('tickets', TicketController::class)->except(['edit', 'update', 'destroy']);
+    Route::resource('tickets', TicketController::class)->except(['destroy']);
     
     // Route for adding comments to tickets
     Route::post('/tickets/{ticket}/comments', [CommentController::class, 'store'])->name('comments.store');
+    
+    Route::middleware(AdminMiddleware::class)->group(function () {
+        Route::get('/admin/dashboard', [AdminController::class, 'dashboard'])->name('admin.dashboard');
+        Route::get('/admin/activitylogs', [ActivityLogController::class, 'index'])->name('admin.activitylogs.index');
+
+        Route::get('/admin/labels', [LabelController::class, 'index'])->name('labels.index');
+        Route::patch('/admin/labels/{label}', [LabelController::class, 'update'])->name('labels.update');
+        Route::post('/admin/labels', [LabelController::class, 'store'])->name('labels.store');
+        Route::delete('/admin/labels/{label}', [LabelController::class, 'destroy'])->name('labels.destroy');
+
+        Route::get('/admin/categories', [CategoryController::class, 'index'])->name('categories.index');
+        Route::patch('/admin/categories/{category}', [CategoryController::class, 'update'])->name('categories.update');
+        Route::post('/admin/categories', [CategoryController::class, 'store'])->name('categories.store');
+        Route::delete('/admin/categories/{category}', [CategoryController::class, 'destroy'])->name('categories.destroy');
+    });
 
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');


### PR DESCRIPTION
Admins see not only tickets table, but also can view more menu items: 1. Dashboard with the amount of tickets per status (total / open / closed, etc.), 2. Manage Labels, Categories, Priorities and Users, in CRUD way. Also, when editing the ticket, admins can assign Agent user to it - other users shouldn't see that field. Also, admins should see the menu item called Logs which lists all changes that happened to all tickets, like history: who created/updated the ticket and when.